### PR TITLE
Removed codeship button 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-AutoBot[ ![Codeship Status for codelion/AutoBot](https://codeship.com/projects/8de6d120-4794-0132-2f6b-16fd1ca0a3af/status?branch=master)](https://codeship.com/projects/45652)
+AutoBot
 =======
 This repo comprises of a set of utility scripts for testing webpages for errors.
 As of now, it consists of:


### PR DESCRIPTION
The codeship button on ReadMe was from the old repo so was failing. There are no tests configured to run anyways so removing it for now. You can add tests and configure them to run through CI later if needed.